### PR TITLE
Normalize the framework name to "ExtJS"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ You may add, edit, or request to remove:
 
 ### General conditions
 
-This is an attempt to make a curated list of useful resources for Sencha Extjs ecosystem.
+This is an attempt to make a curated list of useful resources for Sencha ExtJS ecosystem.
 
 - Submitting software:
   - Must either be free and open source, or have a note which explicitly states that the software is commercial. `(Commercial Software)` will do. Must have an acknowledged open source license to be exempt from the `(Commercial Software)` note requirement.
-- Do not include links to parts of official documentation. It's not useful as every extjs user knows where is this documentation.
+- Do not include links to parts of official documentation. It's not useful as every ExtJS user knows where is this documentation.
 - All resources provided must be free (as in free beer) and without commitment from the user (e.g. no requirement to enter personal details,  no requirement to login with social network ID, etc.)
 - The only exception being Newsletters, where an email address is required by definition. Newsletters are accepted under the condition that an email address is their *only requirement*.
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
-# Awesome Extjs [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome ExtJS [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A curated list of Extjs resources.
+A curated list of ExtJS resources.
 
 *Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.*
 
 Contributions are welcomes. Add links through [pull requests](https://github.com/abenhamdine/awesome-extjs/pulls) or create an [issue](https://github.com/abenhamdine/awesome-extjs/issues) to start a discussion. Please take a look at the [contribution guidelines](CONTRIBUTING.md)
 
-## Last commercial version of Extjs : 6.5.1
-## Last GPL version of Extjs : 6.2.0
+## Last commercial version of ExtJS : 6.5.1
+## Last GPL version of ExtJS : 6.2.0
 
 ## Contents
 
 - [Official resources](#official-resources)
 - [Blogs](#Blogs)
 - [Tutorials, examples](#tutorials,-examples)
-- [Open sources projects using Extjs](#open-sources-projects-using-extjs)
-- [Commercial Software using Extjs](#commercial-software-using-extjs)
-- [Extjs service providers](#extjs-service-providers)
+- [Open sources projects using ExtJS](#open-sources-projects-using-extjs)
+- [Commercial Software using ExtJS](#commercial-software-using-extjs)
+- [ExtJS service providers](#extjs-service-providers)
 - [Books](#books)
 
 ## Official resources
 
-* [Sencha Extjs docs 6.5.1](http://docs.sencha.com/extjs/6.5.1/index.html) - Official documentation of current version.
-* [Sencha blog](https://www.sencha.com/blog/category/sencha-ext-js) - Official Sencha blog for Extjs posts
+* [Sencha ExtJS docs 6.5.1](http://docs.sencha.com/extjs/6.5.1/index.html) - Official documentation of current version.
+* [Sencha blog](https://www.sencha.com/blog/category/sencha-ext-js) - Official Sencha blog for ExtJS posts
 * [Sencha forums](https://www.sencha.com/forum) - Forums for all sencha products
 * [Sencha examples on Github](https://github.com/sencha-extjs-examples) - Examples on Github, different from examples in official docs
-* [ExtReact](https://www.sencha.com/products/extreact/#app) - Extjs components for React
+* [ExtReact](https://www.sencha.com/products/extreact/#app) - ExtJS components for React
 * [Link to GPL Version](https://www.sencha.com/legal/gpl/) - A link to the form to fill to obtain the GPL version
 
 ## Blogs
 
 * [Sencha Guru](https://sencha.guru/) - A blog from Mitchell Simoens, a developper from Sencha Inc.
-* [Blog of Walking Tree](https://walkingtree.tech/index.php/blog) - Blog of WalkingTree, a service provider for Extjs
-* [Blog of Steve Drucker](https://druckit.wordpress.com/) - Some articles about Extjs
-* [Alex'blog](https://abarre.wordpress.com/) - A few articles about Extjs
-* [Blog of Vladimir Popa](http://vadimpopa.com/) - A blog with some good articles about Extjs
+* [Blog of Walking Tree](https://walkingtree.tech/index.php/blog) - Blog of WalkingTree, a service provider for ExtJS
+* [Blog of Steve Drucker](https://druckit.wordpress.com/) - Some articles about ExtJS
+* [Alex'blog](https://abarre.wordpress.com/) - A few articles about ExtJS
+* [Blog of Vladimir Popa](http://vadimpopa.com/) - A blog with some good articles about ExtJS
 * [Anton Fisher's notes](https://antonfisher.com/) - Blog by a javascript developer (extjs, nodejs, bash)
 * [Blog of Modus Create](http://moduscreate.com/category/sencha/)
 * [Reanimatter](http://reanimatter.com/tag/ext-js/)
@@ -42,8 +42,8 @@ Contributions are welcomes. Add links through [pull requests](https://github.com
 ## Tutorials, examples
 
 * [ext4all](https://ext4all.com/) - Exjs code snippets
-* [skirtlesden](http://skirtlesden.com/articles/) - Old (2014) but very good articles about Extjs
-* [senchatutorials](http://senchatutorials.in/) - Step-by-step tutorials for Sencha Ext JS 4.x, 5.x, 6.x and Sencha Touch 2.x
+* [skirtlesden](http://skirtlesden.com/articles/) - Old (2014) but very good articles about ExtJS
+* [senchatutorials](http://senchatutorials.in/) - Step-by-step tutorials for Sencha ExtJS 4.x, 5.x, 6.x and Sencha Touch 2.x
 
 ## Extensions & components
 
@@ -58,7 +58,7 @@ Contributions are welcomes. Add links through [pull requests](https://github.com
 * [Ext.ux.grid.Printer](https://github.com/Arhia/Ext.ux.grid.Printer) - An Extjs 5/6 Component to print grid content
 * [Exportable grid](https://github.com/yorl1n/ext.ExportableGrid) - Wrapper over ExtJs's grid to make grid exportable to xslx format
 * [ExtJS-Grid-PDF-Exporter](https://github.com/shikhirsingh/ExtJS-Grid-PDF-Exporter) - Sample application to export grid content in pdf
-* [DateSlider component for Sencha Extjs](https://github.com/OhmzTech/extjs-dateslider) - A nice date slider
+* [DateSlider component for Sencha ExtJS](https://github.com/OhmzTech/extjs-dateslider) - A nice date slider
 * [Ace editor integration](https://github.com/cadorn/ace-extjs)
 * [Filebrowser component](https://github.com/revolunet/Ext.ux.filebrowser)
 * [Pdf viewer panel](https://github.com/SunboX/ext_ux_pdf_panel)
@@ -71,12 +71,12 @@ Contributions are welcomes. Add links through [pull requests](https://github.com
 * [ExtJS-Wheather-Icons](https://github.com/RichardStyles/ExtJS-Weather-Icons) - ExtJS package to use [Weather icons](https://erikflowers.github.io/weather-icons/)
 * [ExtJS-Material-Icons](https://github.com/RichardStyles/ExtJS-Material-Icons) - Allow use of Material Design Iconic Font Icons in an ExtJS project. (Google icons + extended community icons)
 
-### Integration of Extjs Components with other frameworks
+### Integration of ExtJS Components with other frameworks
 
 * [Connector to Angular2](https://github.com/mgusmano/angular2-extjs)
 * [Ext Reactor](https://github.com/sencha/extjs-reactor) - Official Sencha integration with React
 
-## Open sources projects using Extjs
+## Open sources projects using ExtJS
 
 * [GeoExt](https://github.com/geoext/geoext3) - A JavaScript framework that combines the GIS functionality of OpenLayers with all features of the ExtJS library
 * [Jahia](https://github.com/Jahia) - Comprehensive and integrated open-source Java Digital Experience Platform
@@ -86,15 +86,15 @@ Contributions are welcomes. Add links through [pull requests](https://github.com
 * [Koala](https://github.com/koala-framework/koala-framework) - Framework and CMS based on Zend Framework and ExtJS
 * [Arbela](https://github.com/walkingtree/arbela) - Rich, Extensible, Customizable, and Configurable IoT-ready Dashboard
 
-## Commercial Software using Extjs
+## Commercial Software using ExtJS
 
 ### Desktop apps built with [Electron](https://electron.atom.io/)
 * [Sencha Architect](https://www.sencha.com/products/architect/), [Sencha Test](https://www.sencha.com/products/test/), [Sencha Themer](https://www.sencha.com/products/themer/), [Sencha Inspector](https://www.sencha.com/products/inspector/) - Are build with various versions of ExtJS framework
 
-## Extjs service providers
+## ExtJS service providers
 
 ## Books
 
-* [Mastering ExtJs 2nd Edition](https://www.packtpub.com/web-development/mastering-ext-js-second-edition)
+* [Mastering Ext JS 2nd Edition](https://www.packtpub.com/web-development/mastering-ext-js-second-edition)
 * [Ext JS Application Development Blueprints](https://www.packtpub.com/web-development/ext-js-application-development-blueprints)
 * [Sencha Charts Essentials](https://www.packtpub.com/web-development/sencha-charts-essentials)


### PR DESCRIPTION
The name "ExtJS" seems to be more widely used and it also appears more often in the blogs and books listed as resources. On their website, Sencha seems to stick to the "Ext JS" version. But, as developers we do not like spaces that much 😄 

I just replaced all the "Extjs", "ExtJs", "Ext JS" with "ExtJS" (except for book titles and official description of repos) in an attempt to normalize the name.

I might be biased because I use this naming, or because JavaScript is often abbreviated as "JS".

Not a big deal, but I thought you might want take a look.